### PR TITLE
Query adapt

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .idea
+/target/

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,2 @@
 .idea
-/target/
+target/

--- a/src/main/java/gov/nih/ncats/molwitch/cdk/CdkChemical2FactoryImpl.java
+++ b/src/main/java/gov/nih/ncats/molwitch/cdk/CdkChemical2FactoryImpl.java
@@ -196,8 +196,9 @@ public class CdkChemical2FactoryImpl implements ChemicalImplFactory{
     public ChemicalImpl createFromString(String format, String input) throws IOException {
         try {
             if ("mol".equals(format)) {
-                IAtomContainer mol = SilentChemObjectBuilder.getInstance().newAtomContainer();
-              mol =  new MDLV2000Reader(new StringReader(input)).read(mol);
+                IAtomContainer mol =  CdkUtil.getChemObjectBuilder().newAtomContainer();
+                
+                mol =  new MDLV2000Reader(new StringReader(input)).read(mol);
                 return new CdkChemicalImpl(mol, new MolStringSource(input, ChemicalSource.Type.MOL));
             }else if("sdf".equals(format)){
                 try(IdAwareSdfReader reader = new IdAwareSdfReader(new BufferedReader(new StringReader(input)),SilentChemObjectBuilder.getInstance())){

--- a/src/main/java/gov/nih/ncats/molwitch/cdk/CdkChemicalImpl.java
+++ b/src/main/java/gov/nih/ncats/molwitch/cdk/CdkChemicalImpl.java
@@ -21,15 +21,7 @@
 
 package gov.nih.ncats.molwitch.cdk;
 
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.Iterator;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 import java.util.Map.Entry;
 import java.util.NoSuchElementException;
 import java.util.Optional;
@@ -197,9 +189,7 @@ public class CdkChemicalImpl implements ChemicalImpl<CdkChemicalImpl>{
 	            container = new QueryAtomContainer(container, CHEM_OBJECT_BUILDER);
             }
         }
-	   
 		this.container = container;
-		
 		this.source = source;
 		hydrogenAdder = CDKHydrogenAdder.getInstance(container.getBuilder());
 		cachedSupplierGroup.add(ringsSearcherSupplier);
@@ -733,11 +723,11 @@ public class CdkChemicalImpl implements ChemicalImpl<CdkChemicalImpl>{
 		try {
 			StructureDiagramGenerator coordinateGenerator = new StructureDiagramGenerator(container);
 			this.doWithQueryFixes(()->{
-						try{
-							coordinateGenerator.generateCoordinates();
-						}catch(Exception e2){
-							throw new RuntimeException(e2);
-						}
+				try{
+					coordinateGenerator.generateCoordinates();
+				}catch(Exception e2){
+					throw new RuntimeException(e2);
+				}
 			});
 	
 			container = coordinateGenerator.getMolecule();
@@ -817,20 +807,18 @@ public class CdkChemicalImpl implements ChemicalImpl<CdkChemicalImpl>{
 			doWithQueryFixes(()->{
 				
 				isAromatic=false;
-//		fix();
-				//setImplicitHydrogens();
-			
-			    try {
+
+				try {
 					Kekulization.kekulize(container);
 				} catch (CDKException e) {
 					// TODO Auto-generated catch block
 					throw new RuntimeException(e);
 				}
-			    //kekulize doesn't touch the aromatic bond flags
-			    //so we want to I guess?
-			    for(IBond bond : container.bonds()){
-			        bond.setIsAromatic(false);
-			    }
+				//kekulize doesn't touch the aromatic bond flags
+				//so we want to I guess?
+				for(IBond bond : container.bonds()){
+					bond.setIsAromatic(false);
+				}
 			    
 			});
 		} catch (Exception e) {

--- a/src/main/java/gov/nih/ncats/molwitch/cdk/CdkUtil.java
+++ b/src/main/java/gov/nih/ncats/molwitch/cdk/CdkUtil.java
@@ -94,7 +94,6 @@ public class CdkUtil {
 
 		AtomContainerManipulator.percieveAtomTypesAndConfigureAtoms(container);
 		QueryAtomPerceptor.percieve(container);
-		
 		return container;
 	}
 	
@@ -107,7 +106,6 @@ public class CdkUtil {
 			 .allMatch(ex->ex.type().equals(Expr.Type.ELEMENT))){
 			return "L";
 		}else{
-			
 			return "A";
 		}
 	}
@@ -152,20 +150,12 @@ public class CdkUtil {
     		ibo = BondRef.deref(ibo);
     		if(ibo instanceof QueryBond){
     			ib.setExpression(((QueryBond)ibo).getExpression());
-//    			System.out.println("Aromatic?:" + ibo.isAromatic());
-//    			navNodes(((QueryBond)ibo).getExpression(), (e,l)->{
-//    				System.out.println(rep(" ",e) + l.type() + ":" + l.value());
-//    			},0);
+
     			if(ibo.isAromatic()){
     				ib.setExpression(new Expr(Expr.Type.IS_AROMATIC));
-//    				ib.setIsAromatic(true);
-    			}else{
-    				if(ib.getExpression().type().equals(Expr.Type.ORDER)){
-    					ib.getExpression().setPrimitive(Expr.Type.ALIPHATIC_ORDER, ib.getExpression().value());
-    				}
+    			}else if(ib.getExpression().type().equals(Expr.Type.ORDER)){
+					ib.getExpression().setPrimitive(Expr.Type.ALIPHATIC_ORDER, ib.getExpression().value());
     			}
-    			
-    			
     		}else{
     			if(!ibo.isAromatic()){
     				if(ibo.getOrder()==null || ibo.getOrder().equals(Order.UNSET)){
@@ -181,8 +171,6 @@ public class CdkUtil {
     		if(ib.getExpression().type().equals(Expr.Type.STEREOCHEMISTRY)){
     			ib.setExpression(new Expr(Expr.Type.TRUE));
     		}
-    		
-    		
     	}        	
     	for(int i=0;i<qac.getAtomCount();i++){
     		QueryAtom iat=(QueryAtom)qac.getAtom(i);
@@ -229,7 +217,6 @@ public class CdkUtil {
     	for(IBond ib : mol.bonds()){
     		if(ib.getOrder() == null || ib.getOrder().equals(Order.UNSET))return false;
     	}
-//    	System.out.println("Nothing to see here");
     	return true;
     }
     

--- a/src/test/java/ParseQueryMol.java
+++ b/src/test/java/ParseQueryMol.java
@@ -20,6 +20,7 @@
  */
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -39,7 +40,7 @@ import gov.nih.ncats.molwitch.fingerprint.Fingerprinters.FingerprintSpecificatio
 import gov.nih.ncats.molwitch.search.MolSearcherFactory;
 
 public class ParseQueryMol {
-////
+
     @Test
     public void atomListsAndQueryBondFingerprintsWork() throws IOException {
     	  String mol= "\n" + 
@@ -425,7 +426,7 @@ public class ParseQueryMol {
         Optional<int[]> hit = MolSearcherFactory.create(c).search(c2);
 		
 
-		assertEquals("true",""+hit.isPresent());
+		assertTrue(hit.isPresent());
         
         
     }
@@ -457,16 +458,7 @@ public class ParseQueryMol {
            
            
            Chemical c = Chemical.parse(mol);
-//         IAtomContainer cont = (IAtomContainer) c.getImpl().getWrappedObject();
-//         for(IBond ib : cont.bonds()){
-////      	   QueryBond qb = ((QueryBond)BondRef.deref(ib));
-////      	   CdkUtil.navNodes(((QueryBond)qb).getExpression(), (e,l)->{
-//// 				System.out.println(CdkUtil.rep(" ",e) + l.type() + ":" + l.value());
-//// 			},0);
-//      	   System.out.println(ib.getIndex() + ":" + ib.getOrder() + ":" + ib.isAromatic() + ":" + ib.getClass());
-//      	   
-//         }
-//           c.aromatize();
+
 
            try{
         	   c.generateCoordinates();
@@ -489,7 +481,7 @@ public class ParseQueryMol {
            System.out.println(c2.toMol());
            System.out.println(c2.toSmiles());
            Optional<int[]> hit = MolSearcherFactory.create(c).search(c2);
-           assertEquals("true",""+hit.isPresent());
+           assertTrue(hit.isPresent());
        }
        
        
@@ -636,26 +628,7 @@ public class ParseQueryMol {
 	       c.aromatize();
 	       System.out.println(c.toMol());
 	       System.out.println(c.toSmarts());
-//		   IAtomContainer cont = (IAtomContainer) c.getImpl().getWrappedObject();
-//		   for(IBond ib : cont.bonds()){
-//			   QueryBond qb = ((QueryBond)BondRef.deref(ib));
-//			   CdkUtil.navNodes(((QueryBond)qb).getExpression(), (e,l)->{
-//					System.out.println(CdkUtil.rep(" ",e) + l.type() + ":" + l.value());
-//				},0);
-//			   System.out.println(ib.getIndex() + ":" + ib.getOrder() + ":" + ib.isAromatic() + ":" + ib.getClass());
-//			   
-//		   }
-//		   for(IAtom ia : cont.atoms()){
-//			   IAtom dr=AtomRef.deref(ia);
-//			   if(dr instanceof QueryAtom){
-//		    	   QueryAtom qa = (QueryAtom)dr;
-//		    	   CdkUtil.navNodes(((QueryAtom)qa).getExpression(), (e,l)->{
-//						System.out.println(CdkUtil.rep(" ",e) + l.type() + ":" + l.value());
-//					},0);
-//			   }
-//			   System.out.println(ia.getAtomicNumber() + ":" + ia.getSymbol() + ":" + ia.isAromatic() + ":" + ia.getClass());
-//			   
-//		   }
+
 	       
 	       String mol2="COC1=CC=C(O)C2=C(O)C(C)=C3OC(C)(O)C(=O)C3=C12";
 	       Chemical c2 = Chemical.parse(mol2);
@@ -668,24 +641,23 @@ public class ParseQueryMol {
 	       System.out.println(c2.toMol());
 	       System.out.println(c2.toSmiles());
 	       Optional<int[]> hit = MolSearcherFactory.create(c).search(c2);
-	       assertEquals("true",""+hit.isPresent());
+	       assertTrue(hit.isPresent());
        }
-       
        @Test
-   	public void removeAtomThenReAdd() throws Exception{
-   		Chemical c=Chemical.createFromSmiles("CCCCC");
-   		Atom remAt=c.getAtom(3);
-   		List<Bond> removedBonds = new ArrayList<>();
-   		for(Bond b : remAt.getBonds()){
-   			removedBonds.add(c.removeBond(b));
-   		}
-   		
-   		c.removeAtom(remAt);
-   		
-   		c.addAtom(remAt);
-   		for(Bond b : removedBonds){
-   			c.addBond(b);
-   		}
-   		assertEquals("CCCCC", c.toSmiles());
-   	}
+	   public void removeAtomThenReAdd() throws Exception{
+			Chemical c=Chemical.createFromSmiles("CCCCC");
+			Atom remAt=c.getAtom(3);
+			List<Bond> removedBonds = new ArrayList<>();
+			for(Bond b : remAt.getBonds()){
+				removedBonds.add(c.removeBond(b));
+			}
+
+			c.removeAtom(remAt);
+
+			c.addAtom(remAt);
+			for(Bond b : removedBonds){
+				c.addBond(b);
+			}
+			assertEquals("CCCCC", c.toSmiles());
+		}
 }

--- a/src/test/java/ParseQueryMol.java
+++ b/src/test/java/ParseQueryMol.java
@@ -19,14 +19,18 @@
  *  Boston, MA 02111-1307 USA
  */
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
 
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.BitSet;
+import java.util.List;
 import java.util.Optional;
 
 import org.junit.Test;
 
+import gov.nih.ncats.molwitch.Atom;
+import gov.nih.ncats.molwitch.Bond;
 import gov.nih.ncats.molwitch.Chemical;
 import gov.nih.ncats.molwitch.fingerprint.Fingerprint;
 import gov.nih.ncats.molwitch.fingerprint.Fingerprinter;
@@ -35,7 +39,7 @@ import gov.nih.ncats.molwitch.fingerprint.Fingerprinters.FingerprintSpecificatio
 import gov.nih.ncats.molwitch.search.MolSearcherFactory;
 
 public class ParseQueryMol {
-
+////
     @Test
     public void atomListsAndQueryBondFingerprintsWork() throws IOException {
     	  String mol= "\n" + 
@@ -230,6 +234,7 @@ public class ParseQueryMol {
         System.out.println(smarts);
         
         
+        
         String mm="\n" + 
         		"   JSDraw209242017082D\n" + 
         		"\n" + 
@@ -295,7 +300,7 @@ public class ParseQueryMol {
 
         
     }
-    
+   
     @Test
     public void atomListsAndQueryBondStructureSearchWork() throws IOException {
         String mol= "\n" + 
@@ -424,4 +429,263 @@ public class ParseQueryMol {
         
         
     }
+    
+       @Test
+       public void ensureAnyBondAndAromatizationWorksForSubstructureSearch() throws IOException {
+           String mol= "\n" + 
+           		"   JSDraw209252000242D\n" + 
+           		"\n" + 
+           		"  8  8  0  0  0  0            999 V2000\n" + 
+           		"   28.1035   -4.9661    0.0000 L   0  0  0  0  0  0  0  0  0  0  0  0\n" + 
+           		"   29.4545   -5.7461    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0\n" + 
+           		"   30.8055   -4.9661    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0\n" + 
+           		"   32.1565   -5.7461    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0\n" + 
+           		"   32.1565   -7.3060    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0\n" + 
+           		"   30.8055   -8.0860    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0\n" + 
+           		"   29.4545   -7.3060    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0\n" + 
+           		"   33.5073   -8.0860    0.0000 O   0  0  0  0  0  0  0  0  0  0  0  0\n" + 
+           		"  1  2  8  0  0  0  0\n" + 
+           		"  2  3  1  0  0  0  0\n" + 
+           		"  3  4  2  0  0  0  0\n" + 
+           		"  4  5  1  0  0  0  0\n" + 
+           		"  5  6  2  0  0  0  0\n" + 
+           		"  6  7  1  0  0  0  0\n" + 
+           		"  2  7  2  0  0  0  0\n" + 
+           		"  5  8  1  0  0  0  0\n" + 
+           		"M  ALS   1  2 F N   O   \n" + 
+           		"M  END";
+           
+           
+           Chemical c = Chemical.parse(mol);
+//         IAtomContainer cont = (IAtomContainer) c.getImpl().getWrappedObject();
+//         for(IBond ib : cont.bonds()){
+////      	   QueryBond qb = ((QueryBond)BondRef.deref(ib));
+////      	   CdkUtil.navNodes(((QueryBond)qb).getExpression(), (e,l)->{
+//// 				System.out.println(CdkUtil.rep(" ",e) + l.type() + ":" + l.value());
+//// 			},0);
+//      	   System.out.println(ib.getIndex() + ":" + ib.getOrder() + ":" + ib.isAromatic() + ":" + ib.getClass());
+//      	   
+//         }
+//           c.aromatize();
+
+           try{
+        	   c.generateCoordinates();
+           }catch(Exception e){
+        	   e.printStackTrace();
+           }
+           c.aromatize();
+           System.out.println(c.toMol());
+           System.out.println(c.toSmarts());
+           
+           
+           String mol2="NC1=CC(O)=C(O)C=C1";
+           Chemical c2 = Chemical.parse(mol2);
+           c2.aromatize();
+           try{
+        	   c2.generateCoordinates();
+           }catch(Exception e){
+        	   e.printStackTrace();
+           }
+           System.out.println(c2.toMol());
+           System.out.println(c2.toSmiles());
+           Optional<int[]> hit = MolSearcherFactory.create(c).search(c2);
+           assertEquals("true",""+hit.isPresent());
+       }
+       
+       
+       @Test
+       public void ensureAnyBondAndAromatizationInComplexExampleWorksForSubstructureSearch() throws IOException {
+           String mol= "\n" + 
+           		"  CDK     09252009303D\n" + 
+           		"\n" + 
+           		" 19 21  0  0  0  0  0  0  0  0999 V2000\n" + 
+           		"   -1.9500    2.4000    0.0000 L   0  0  0  0  0  0  0  0  0  0  0  0\n" + 
+           		"   -1.9500    0.9000    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0\n" + 
+           		"   -0.6500    0.1500    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0\n" + 
+           		"    0.6500    0.9000    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0\n" + 
+           		"    1.9500    0.1500    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0\n" + 
+           		"    3.0600    1.1500    0.0000 O   0  0  0  0  0  0  0  0  0  0  0  0\n" + 
+           		"    2.4500    2.5200    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0\n" + 
+           		"    3.8762    2.9846    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0\n" + 
+           		"    2.1359    3.9867    0.0000 O   0  0  0  0  0  0  0  0  0  0  0  0\n" + 
+           		"    0.9600    2.3600    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0\n" + 
+           		"   -0.0451    3.4735    0.0000 O   0  0  0  0  0  0  0  0  0  0  0  0\n" + 
+           		"    1.9500   -1.3500    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0\n" + 
+           		"    0.6500   -2.1000    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0\n" + 
+           		"    0.6500   -3.6000    0.0000 O   0  0  0  0  0  0  0  0  0  0  0  0\n" + 
+           		"   -0.6500   -1.3500    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0\n" + 
+           		"   -1.9500   -2.1000    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0\n" + 
+           		"   -1.9500   -3.6000    0.0000 O   0  0  0  0  0  0  0  0  0  0  0  0\n" + 
+           		"   -3.2500   -1.3500    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0\n" + 
+           		"   -3.2500    0.1500    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0\n" + 
+           		"  1  2  8  0  0  0  0\n" + 
+           		"  2 19  4  0  0  0  0\n" + 
+           		"  2  3  4  0  0  0  0\n" + 
+           		"  3 15  4  0  0  0  0\n" + 
+           		"  3  4  4  0  0  0  0\n" + 
+           		"  4 10  6  0  0  0  0\n" + 
+           		"  4  5  4  0  0  0  0\n" + 
+           		"  5  6  6  0  0  0  0\n" + 
+           		"  6  7  6  0  0  0  0\n" + 
+           		"  7  8  6  0  0  0  0\n" + 
+           		"  7  9  6  0  0  0  0\n" + 
+           		"  7 10  6  0  0  0  0\n" + 
+           		" 10 11  2  0  0  0  0\n" + 
+           		"  5 12  4  0  0  0  0\n" + 
+           		" 12 13  4  0  0  0  0\n" + 
+           		" 13 14  6  0  0  0  0\n" + 
+           		" 13 15  4  0  0  0  0\n" + 
+           		" 15 16  4  0  0  0  0\n" + 
+           		" 16 17  6  0  0  0  0\n" + 
+           		" 16 18  4  0  0  0  0\n" + 
+           		" 18 19  4  0  0  0  0\n" + 
+      		    "M  ALS   1  2 F O   N   \n" + 
+           		"M  END";
+                    
+           Chemical c = Chemical.parse(mol);
+           try{
+        	   c.generateCoordinates();
+           }catch(Exception e){
+        	   e.printStackTrace();
+           }
+           c.aromatize();
+           System.out.println(c.toMol());
+           System.out.println(c.toSmarts());
+           
+           
+           String mol2="COC1=CC=C(O)C2=C(O)C(C)=C3OC(C)(O)C(=O)C3=C12";
+           Chemical c2 = Chemical.parse(mol2);
+           c2.aromatize();
+           try{
+        	   c2.generateCoordinates();
+           }catch(Exception e){
+        	   e.printStackTrace();
+           }
+           System.out.println(c2.toMol());
+           System.out.println(c2.toSmiles());
+           Optional<int[]> hit = MolSearcherFactory.create(c).search(c2);
+           assertEquals("true",""+hit.isPresent());
+       }
+       
+       
+       @Test
+       public void ensureAnyBondAndAromatizationInSimpleExampleFromSmartsWorksForSubstructureSearch() throws IOException {
+           String mol= "[#7,#8]~C1=CC=CC=C1";
+                    
+           
+	       Chemical c = Chemical.parse(mol);
+	       try{
+	    	   c.generateCoordinates();
+	       }catch(Exception e){
+	    	   e.printStackTrace();
+	       }
+	       c.aromatize();
+	       System.out.println(c.toMol());
+	       System.out.println(c.toSmarts());
+//		   IAtomContainer cont = (IAtomContainer) c.getImpl().getWrappedObject();
+//		   for(IBond ib : cont.bonds()){
+//			   QueryBond qb = ((QueryBond)BondRef.deref(ib));
+//			   CdkUtil.navNodes(((QueryBond)qb).getExpression(), (e,l)->{
+//					System.out.println(CdkUtil.rep(" ",e) + l.type() + ":" + l.value());
+//				},0);
+//			   System.out.println(ib.getIndex() + ":" + ib.getOrder() + ":" + ib.isAromatic() + ":" + ib.getClass());
+//			   
+//		   }
+//		   for(IAtom ia : cont.atoms()){
+//			   IAtom dr=AtomRef.deref(ia);
+//			   if(dr instanceof QueryAtom){
+//		    	   QueryAtom qa = (QueryAtom)dr;
+//		    	   CdkUtil.navNodes(((QueryAtom)qa).getExpression(), (e,l)->{
+//						System.out.println(CdkUtil.rep(" ",e) + l.type() + ":" + l.value());
+//					},0);
+//			   }
+//			   System.out.println(ia.getAtomicNumber() + ":" + ia.getSymbol() + ":" + ia.isAromatic() + ":" + ia.getClass());
+//			   
+//		   }
+	       
+	       String mol2="OC1=CC=CC=C1";
+	       Chemical c2 = Chemical.parse(mol2);
+	       c2.aromatize();
+	       try{
+	    	   c2.generateCoordinates();
+	       }catch(Exception e){
+	    	   e.printStackTrace();
+	       }
+	       System.out.println(c2.toMol());
+	       System.out.println(c2.toSmiles());
+	       Optional<int[]> hit = MolSearcherFactory.create(c).search(c2);
+	       assertEquals("true",""+hit.isPresent());
+       }
+       
+
+       //
+      	//String structure="[#7,#8]~C1=c2c3c(OC([#6])(O)C3=O)cc(O)c2=C(O)\\C=C/1";
+      	//structureIndexer.add("1", "COC1=CC=C(O)C2=C(O)C(C)=C3OC(C)(O)C(=O)C3=C12");
+      	//structureIndexer.add("2", "CC1=C2OC(C)(O)C(=O)C2=C3C4=C(C=C(O)C3=C1O)N5C=CC=CC5=N4");
+       @Test
+       public void ensureAnyBondAndAromatizationInComplexExampleFromSmartsWorksForSubstructureSearch() throws IOException {
+           String mol= "[#7,#8]~C1=c2c3c(OC([#6])(O)C3=O)cc(O)c2=C(O)\\C=C/1";
+                    
+           
+	       Chemical c = Chemical.parse(mol);
+	       try{
+	    	   c.generateCoordinates();
+	       }catch(Exception e){
+	    	   e.printStackTrace();
+	       }
+	       c.aromatize();
+	       System.out.println(c.toMol());
+	       System.out.println(c.toSmarts());
+//		   IAtomContainer cont = (IAtomContainer) c.getImpl().getWrappedObject();
+//		   for(IBond ib : cont.bonds()){
+//			   QueryBond qb = ((QueryBond)BondRef.deref(ib));
+//			   CdkUtil.navNodes(((QueryBond)qb).getExpression(), (e,l)->{
+//					System.out.println(CdkUtil.rep(" ",e) + l.type() + ":" + l.value());
+//				},0);
+//			   System.out.println(ib.getIndex() + ":" + ib.getOrder() + ":" + ib.isAromatic() + ":" + ib.getClass());
+//			   
+//		   }
+//		   for(IAtom ia : cont.atoms()){
+//			   IAtom dr=AtomRef.deref(ia);
+//			   if(dr instanceof QueryAtom){
+//		    	   QueryAtom qa = (QueryAtom)dr;
+//		    	   CdkUtil.navNodes(((QueryAtom)qa).getExpression(), (e,l)->{
+//						System.out.println(CdkUtil.rep(" ",e) + l.type() + ":" + l.value());
+//					},0);
+//			   }
+//			   System.out.println(ia.getAtomicNumber() + ":" + ia.getSymbol() + ":" + ia.isAromatic() + ":" + ia.getClass());
+//			   
+//		   }
+	       
+	       String mol2="COC1=CC=C(O)C2=C(O)C(C)=C3OC(C)(O)C(=O)C3=C12";
+	       Chemical c2 = Chemical.parse(mol2);
+	       c2.aromatize();
+	       try{
+	    	   c2.generateCoordinates();
+	       }catch(Exception e){
+	    	   e.printStackTrace();
+	       }
+	       System.out.println(c2.toMol());
+	       System.out.println(c2.toSmiles());
+	       Optional<int[]> hit = MolSearcherFactory.create(c).search(c2);
+	       assertEquals("true",""+hit.isPresent());
+       }
+       
+       @Test
+   	public void removeAtomThenReAdd() throws Exception{
+   		Chemical c=Chemical.createFromSmiles("CCCCC");
+   		Atom remAt=c.getAtom(3);
+   		List<Bond> removedBonds = new ArrayList<>();
+   		for(Bond b : remAt.getBonds()){
+   			removedBonds.add(c.removeBond(b));
+   		}
+   		
+   		c.removeAtom(remAt);
+   		
+   		c.addAtom(remAt);
+   		for(Bond b : removedBonds){
+   			c.addBond(b);
+   		}
+   		assertEquals("CCCCC", c.toSmiles());
+   	}
 }


### PR DESCRIPTION
This does a few things related to handling/processing SMARTS for searches. Here's what you need to know:

1. Query bond/atom stuff doesn't play well with the CDK aromatic model. That model wants plain-ol atoms and bonds with certain set properties, and well error out if things are to query-like.
2. To fix this, there's a little method that forces all the outlier bonds/atoms to be a simple placeholder type, does an operation, and then puts them back after detecting aromaticity.
3. After aromatizing query bonds/atoms, while the surface-level flags may be set, the underlying `Expr` values may remain to be for their explicit bond types. To fix this, there's an extra step where query atoms/bonds are set to have the new aromatic criteria based on aromatizing. This means that aromatizing is probably lossy, and re-kekulizing won't always work as expected for query chemicals ... but that's probably okay.
4. There's a strange case with STEREOCHEMISTRY query bonds where those also can't be properly aromatized. If you're aromatizing now, and that criteria is met, it's set to be a single-or-aromatic bond instead. This loses specificity for a search, and may need to be fixed later.

