### PR TITLE
Aromatic and valency fixes

### DIFF
--- a/src/main/java/gov/nih/ncats/molwitch/cdk/CdkAtom.java
+++ b/src/main/java/gov/nih/ncats/molwitch/cdk/CdkAtom.java
@@ -298,6 +298,10 @@ public class CdkAtom implements Atom{
 		if("S".equals(value)) {
 			return Chirality.S;
 		}
+		if("EITHER".equals(value)) {
+			return Chirality.Parity_Either;
+		}
+		
 		return Chirality.Non_Chiral;
 	}
 

--- a/src/main/java/gov/nih/ncats/molwitch/cdk/CdkAtom.java
+++ b/src/main/java/gov/nih/ncats/molwitch/cdk/CdkAtom.java
@@ -382,8 +382,8 @@ public class CdkAtom implements Atom{
 	@Override
 	public OptionalInt getValence() {
 		parent.perceiveAtomTypesOfNonQueryAtoms.get();
-		Integer valence= atom.getValency();
 		
+		Integer valence= atom.getValency();
 		if(valence ==null) {
 			return OptionalInt.empty();
 		}
@@ -395,7 +395,34 @@ public class CdkAtom implements Atom{
 	public boolean hasValenceError() {
 		//after perceiving atom types valence should not be null unless there's an error?
 		//TODO maybe not set on query atoms?
-		return !getValence().isPresent();
+		OptionalInt opin=getValence();
+		if(!opin.isPresent())return true;
+		
+		int v = opin.getAsInt();
+		
+		// TODO: Need a real valence model check here ...
+		// CDK probably has one. Generally specific elements
+		// are only allowed to have certain valences. That is,
+		// there are only certain bond count/charge/radical
+		// configurations that are allowed. The most common
+		// case we're worried about though is pentavalent
+		// carbon. So we'll currently just throw an error
+		// on that one case.
+		
+		if("C".equals(this.getSymbol()) && v>4){
+			return true;
+		}
+		if("N".equals(this.getSymbol())){
+			if(v==4){
+				if(this.getCharge()==1){
+					return false;
+				}else{
+					return true;
+				}
+			}
+		}
+		
+		return false;
 	}
 
 	@Override

--- a/src/main/java/gov/nih/ncats/molwitch/cdk/CdkChemical2FactoryImpl.java
+++ b/src/main/java/gov/nih/ncats/molwitch/cdk/CdkChemical2FactoryImpl.java
@@ -192,14 +192,26 @@ public class CdkChemical2FactoryImpl implements ChemicalImplFactory{
 		}
 	}
 
-    @Override
+	@Override
     public ChemicalImpl createFromString(String format, String input) throws IOException {
         try {
             if ("mol".equals(format)) {
-                IAtomContainer mol =  CdkUtil.getChemObjectBuilder().newAtomContainer();
-                
-                mol =  new MDLV2000Reader(new StringReader(input)).read(mol);
-                return new CdkChemicalImpl(mol, new MolStringSource(input, ChemicalSource.Type.MOL));
+            	try(ChemicalImplReader reader = createFrom(new BufferedReader(new StringReader(input)), null)){
+        			return reader.read();
+        		}
+            	//TODO: Obviously the real way to parse a mol is below, but sometimes this gives different
+            	//stereo results than above. It's unclear why. For now, it uses the above because it's
+            	//more often correct with stereo.
+            	
+            	
+//                IAtomContainer mol =  CdkUtil.getChemObjectBuilder().newAtomContainer();
+//                
+//                try(MDLV2000Reader reader = new MDLV2000Reader(new StringReader(input))){
+//                	mol =  reader.read(mol);
+//                }
+//                return new CdkChemicalImpl(mol, new MolStringSource(input, ChemicalSource.Type.MOL));
+            	
+            	
             }else if("sdf".equals(format)){
                 try(IdAwareSdfReader reader = new IdAwareSdfReader(new BufferedReader(new StringReader(input)),SilentChemObjectBuilder.getInstance())){
 					IAtomContainer mol = reader.next();

--- a/src/main/java/gov/nih/ncats/molwitch/cdk/CdkChemical2FactoryImpl.java
+++ b/src/main/java/gov/nih/ncats/molwitch/cdk/CdkChemical2FactoryImpl.java
@@ -113,10 +113,10 @@ public class CdkChemical2FactoryImpl implements ChemicalImplFactory{
 
 
 
-		StructureDiagramGenerator coordinateGenerator = new StructureDiagramGenerator(mol);
-		coordinateGenerator.generateExperimentalCoordinates();
+		//StructureDiagramGenerator coordinateGenerator = new StructureDiagramGenerator(mol);
+		//coordinateGenerator.generateExperimentalCoordinates();
 		//coordinateGenerator.generateCoordinates(coordinateGenerator.DEFAULT_BOND_VECTOR, true, true);
-		mol = coordinateGenerator.getMolecule();
+		//mol = coordinateGenerator.getMolecule();
 
 
 		return mol;

--- a/src/main/java/gov/nih/ncats/molwitch/cdk/CdkChemicalImpl.java
+++ b/src/main/java/gov/nih/ncats/molwitch/cdk/CdkChemicalImpl.java
@@ -90,6 +90,7 @@ import org.openscience.cdk.tools.manipulator.AtomContainerManipulator;
 import org.openscience.cdk.tools.manipulator.AtomTypeManipulator;
 import org.openscience.cdk.tools.manipulator.MolecularFormulaManipulator;
 import org.openscience.cdk.tools.periodictable.PeriodicTable;
+import org.xmlcml.cml.base.CMLElement.Hybridization;
 
 import gov.nih.ncats.common.util.CachedSupplier;
 import gov.nih.ncats.common.util.CachedSupplierGroup;
@@ -142,6 +143,36 @@ public class CdkChemicalImpl implements ChemicalImpl<CdkChemicalImpl>{
     
     CachedSupplier<Void> cahnIngoldPrelogSupplier = CachedSupplier.of(()->{
 	    	CIPTool.label(container);
+	    	Stereocenters  centers   = Stereocenters.of(container);
+	    	for (int i = 0; i < container.getAtomCount(); i++) {
+	    		switch(centers.stereocenterType(i)){
+					case Non:
+						break;
+					case Para:
+					case Potential:
+						break;
+					case True:
+						IAtom ai=container.getAtom(i);
+						if(ai.getProperty(CDKConstants.CIP_DESCRIPTOR) == null){
+							// we only really set it if it's tetrahedral CARBON
+							// right now,
+							boolean bailout=false;
+							for(IBond ib:ai.bonds()){
+								if(!Order.SINGLE.equals(ib.getOrder())){
+									bailout=true;
+									break;
+								}								
+							}
+							if(bailout)continue;
+							
+							container.getAtom(i).setProperty(CDKConstants.CIP_DESCRIPTOR, "EITHER");
+							
+						}
+						break;
+					default:
+						break;
+	    		}
+	    	}
 	    	return null;
     }
     	);

--- a/src/main/java/gov/nih/ncats/molwitch/cdk/CdkChemicalImpl.java
+++ b/src/main/java/gov/nih/ncats/molwitch/cdk/CdkChemicalImpl.java
@@ -710,9 +710,6 @@ public class CdkChemicalImpl implements ChemicalImpl<CdkChemicalImpl>{
         for (IAtom atom : container.atoms()) {
 
         	try{
-//        	if(AtomRef.deref(atom) instanceof QueryAtom){
-//        		continue;
-//			}
             IAtomType matched = matcher.findMatchingAtomType(container, atom);
             if (matched != null) {
             		try{

--- a/src/main/java/gov/nih/ncats/molwitch/cdk/CdkChemicalImpl.java
+++ b/src/main/java/gov/nih/ncats/molwitch/cdk/CdkChemicalImpl.java
@@ -547,7 +547,7 @@ public class CdkChemicalImpl implements ChemicalImpl<CdkChemicalImpl>{
 		Map<IAtom, Integer> oldAI = new HashMap<>();
 		Map<IAtom, Integer> oldIH = new HashMap<>();
 		Map<IAtom, Integer> oldFC = new HashMap<>();
-		Map<IBond, Integer> oldOrder = new HashMap<>();
+		Map<IBond, Order> oldOrder = new HashMap<>();
 		
 		for(IAtom atom : container.atoms()){
 	         if(atom.getAtomicNumber()==null){
@@ -560,27 +560,30 @@ public class CdkChemicalImpl implements ChemicalImpl<CdkChemicalImpl>{
 	         }
 	         if(atom.getImplicitHydrogenCount()==null){
 	        	 oldIH.put(atom, null);
-	        	 atom.setImplicitHydrogenCount(0);
+	        	 //this is really unfortunate, because it 
+	        	 atom.setImplicitHydrogenCount(0);	        	 
 	         }
 	         
 	    } 
-		for(IBond bond : container.bonds()){
-			if(bond.getOrder()==null || bond.getOrder().equals(Order.UNSET)){
-				if(bond instanceof QueryBond){
-					QueryBond qb = (QueryBond)bond;
-					if(qb.getExpression().type().equals(Expr.Type.ALIPHATIC_ORDER)||qb.getExpression().type().equals(Expr.Type.ORDER)){
-						bond.setOrder(Order.values()[qb.getExpression().value()-1]);
-						oldOrder.put(bond, null);
-					}else{
-						bond.setOrder(Order.SINGLE);
-						oldOrder.put(bond, null);
-					}
-				}else{
-					bond.setOrder(Order.SINGLE);
-					oldOrder.put(bond, null);
-				}
-			}
-		}
+//		for(IBond bond : container.bonds()){
+//			if(bond.getOrder()==null || bond.getOrder().equals(Order.UNSET)){
+//				Order oorder=bond.getOrder();
+//				if(bond instanceof QueryBond){
+//					QueryBond qb = (QueryBond)bond;
+//					if(qb.getExpression().type().equals(Expr.Type.ALIPHATIC_ORDER)||qb.getExpression().type().equals(Expr.Type.ORDER)){
+//						
+//						bond.setOrder(Order.values()[qb.getExpression().value()-1]);
+//						oldOrder.put(bond, oorder);
+//					}else{
+//						bond.setOrder(Order.SINGLE);
+//						oldOrder.put(bond, oorder);
+//					}
+//				}else{
+//					bond.setOrder(Order.SINGLE);
+//					oldOrder.put(bond, oorder);
+//				}
+//			}
+//		}
 		
 		try{
 			r.run();
@@ -594,9 +597,9 @@ public class CdkChemicalImpl implements ChemicalImpl<CdkChemicalImpl>{
 	        for(IAtom at: oldFC.keySet()){
 	        	at.setFormalCharge(null);
 	        }
-	        for(IBond ib: oldOrder.keySet()){
-	        	ib.setOrder(Order.UNSET);
-	        }
+//	        for(IBond ib: oldOrder.keySet()){
+//	        	ib.setOrder(oldOrder.get(ib));
+//	        }
 		}
 	}
 
@@ -634,9 +637,9 @@ public class CdkChemicalImpl implements ChemicalImpl<CdkChemicalImpl>{
 			
 			perceiveAtomTypesOfNonQueryAtoms.get();
 //			fix();
-			
+
 			kekulize();
-			
+
 			setImplicitHydrogens();
 			doWithQueryFixes(()->aromaticity.apply(container));
 			
@@ -682,7 +685,7 @@ public class CdkChemicalImpl implements ChemicalImpl<CdkChemicalImpl>{
 			// TODO Auto-generated catch block
 			e.printStackTrace();
 		}
-		isAromatic = true;
+//		isAromatic = true;
 	}
 	
 	private void percieveAtomTypeAndConfigureNonQueryAtoms() throws CDKException{
@@ -690,6 +693,9 @@ public class CdkChemicalImpl implements ChemicalImpl<CdkChemicalImpl>{
         for (IAtom atom : container.atoms()) {
 
         	try{
+//        	if(AtomRef.deref(atom) instanceof QueryAtom){
+//        		continue;
+//			}
             IAtomType matched = matcher.findMatchingAtomType(container, atom);
             if (matched != null) {
             		try{

--- a/src/main/java/gov/nih/ncats/molwitch/cdk/CdkChemicalInchiImplFactory.java
+++ b/src/main/java/gov/nih/ncats/molwitch/cdk/CdkChemicalInchiImplFactory.java
@@ -88,7 +88,9 @@ public class CdkChemicalInchiImplFactory implements InchiImplFactory{
 		try {
 			//need to pass list options (even empty) to get AuxInfo...
 //			System.out.println("computing inchi for " + (chemical.getSource().isPresent()? chemical.getSource().get().getData() : "NO SOURCE"));
-			InChIGenerator gen = factory.getInChIGenerator(CdkUtil.toAtomContainer(handleQueryAtoms(chemical)), Collections.emptyList());
+			Chemical ichem=handleQueryAtoms(chemical);
+			ichem.kekulize();
+			InChIGenerator gen = factory.getInChIGenerator(CdkUtil.toAtomContainer(ichem), Collections.emptyList());
 		
 			InChiResult.Status status = toChemkitStatus(gen.getReturnStatus());
 //			System.out.println("INCHI STATUS =  " + status);

--- a/src/main/java/gov/nih/ncats/molwitch/cdk/CdkChemicalInchiImplFactory.java
+++ b/src/main/java/gov/nih/ncats/molwitch/cdk/CdkChemicalInchiImplFactory.java
@@ -88,8 +88,11 @@ public class CdkChemicalInchiImplFactory implements InchiImplFactory{
 		try {
 			//need to pass list options (even empty) to get AuxInfo...
 //			System.out.println("computing inchi for " + (chemical.getSource().isPresent()? chemical.getSource().get().getData() : "NO SOURCE"));
+//			chemical.aromatize();
+			
 			Chemical ichem=handleQueryAtoms(chemical);
-			ichem.kekulize();
+			chemical.kekulize();
+			
 			InChIGenerator gen = factory.getInChIGenerator(CdkUtil.toAtomContainer(ichem), Collections.emptyList());
 		
 			InChiResult.Status status = toChemkitStatus(gen.getReturnStatus());

--- a/src/main/java/gov/nih/ncats/molwitch/cdk/CdkChemicalInchiImplFactory.java
+++ b/src/main/java/gov/nih/ncats/molwitch/cdk/CdkChemicalInchiImplFactory.java
@@ -91,7 +91,7 @@ public class CdkChemicalInchiImplFactory implements InchiImplFactory{
 //			chemical.aromatize();
 			
 			Chemical ichem=handleQueryAtoms(chemical);
-			chemical.kekulize();
+			ichem.kekulize();
 			
 			InChIGenerator gen = factory.getInChIGenerator(CdkUtil.toAtomContainer(ichem), Collections.emptyList());
 		

--- a/src/main/java/gov/nih/ncats/molwitch/cdk/CdkUtil.java
+++ b/src/main/java/gov/nih/ncats/molwitch/cdk/CdkUtil.java
@@ -153,6 +153,7 @@ public class CdkUtil {
 
     			if(ibo.isAromatic()){
     				ib.setExpression(new Expr(Expr.Type.IS_AROMATIC));
+    				
     			}else if(ib.getExpression().type().equals(Expr.Type.ORDER)){
 					ib.getExpression().setPrimitive(Expr.Type.ALIPHATIC_ORDER, ib.getExpression().value());
     			}

--- a/src/test/java/TestChemicalValidation.java
+++ b/src/test/java/TestChemicalValidation.java
@@ -1,0 +1,62 @@
+/*
+ * NCATS-MOLWITCH-CDK
+ *
+ * Copyright (c) 2020.
+ *
+ * This work is free software; you can redistribute it and/or modify it under the terms of the
+ * GNU Lesser General Public License as published by the Free Software Foundation;
+ * either version 2.1 of the License, or (at your option) any later version.
+ *
+ * This work is distributed in the hope that it will be useful, but without any warranty;
+ * without even the implied warranty of merchantability or fitness for a particular purpose.
+ * See the GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along with this library;
+ *  if not, write to:
+ *
+ *  the Free Software Foundation, Inc.
+ *  59 Temple Place, Suite 330
+ *  Boston, MA 02111-1307 USA
+ */
+
+import static org.junit.Assert.assertEquals;
+
+import java.util.stream.Collectors;
+
+import org.junit.Test;
+
+import gov.nih.ncats.molwitch.Chemical;
+import gov.nih.ncats.molwitch.Chirality;
+import gov.nih.ncats.molwitch.io.ChemicalReaderFactory;
+
+public class TestChemicalValidation {
+
+	@Test
+   	public void testPentavalent() throws Exception {
+   		Chemical c=Chemical.parse("\n" + 
+   				"   JSDraw209262021142D\n" + 
+   				"\n" + 
+   				"  6  5  0  0  0  0            999 V2000\n" + 
+   				"   21.2160   -6.7742    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0\n" + 
+   				"   22.5670   -5.9942    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0\n" + 
+   				"   21.2160   -8.3342    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0\n" + 
+   				"   19.8650   -5.9942    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0\n" + 
+   				"   21.2160   -5.2142    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0\n" + 
+   				"   19.8650   -7.5542    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0\n" + 
+   				"  1  2  1  0  0  0  0\n" + 
+   				"  1  3  1  0  0  0  0\n" + 
+   				"  1  4  1  0  0  0  0\n" + 
+   				"  1  5  1  0  0  0  0\n" + 
+   				"  1  6  1  0  0  0  0\n" + 
+   				"M  END");
+   		
+   		long terror=c.atoms()
+   				.peek(ca->System.out.println(ca.getValence().getAsInt()))
+   				.filter(ca->ca.hasValenceError()).count();
+   		
+   		assertEquals(1,terror);
+   		
+   		
+
+   	}
+}

--- a/src/test/java/TestChemicalValidation.java
+++ b/src/test/java/TestChemicalValidation.java
@@ -27,6 +27,8 @@ import org.junit.Test;
 
 import gov.nih.ncats.molwitch.Chemical;
 import gov.nih.ncats.molwitch.Chirality;
+import gov.nih.ncats.molwitch.Bond.BondType;
+import gov.nih.ncats.molwitch.inchi.InChiResult;
 import gov.nih.ncats.molwitch.io.ChemicalReaderFactory;
 
 public class TestChemicalValidation {
@@ -57,6 +59,64 @@ public class TestChemicalValidation {
    		assertEquals(1,terror);
    		
    		
+
+   	}
+ 	@Test
+   	public void testInchiAromatic() throws Exception {
+   		Chemical c=Chemical.parse("\n" + 
+   				"   JSDraw209262021582D\n" + 
+   				"\n" + 
+   				"  6  6  0  0  0  0              0 V2000\n" + 
+   				"   21.8408   -6.9164    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0\n" + 
+   				"   23.1920   -6.1369    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0\n" + 
+   				"   24.5432   -6.9164    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0\n" + 
+   				"   24.5432   -8.4756    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0\n" + 
+   				"   21.8408   -8.4756    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0\n" + 
+   				"   23.1920   -9.2551    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0\n" + 
+   				"  1  2  4  0  0  0  0\n" + 
+   				"  2  3  4  0  0  0  0\n" + 
+   				"  3  4  4  0  0  0  0\n" + 
+   				"  1  5  4  0  0  0  0\n" + 
+   				"  5  6  4  0  0  0  0\n" + 
+   				"  4  6  4  0  0  0  0\n" + 
+   				"M  END");
+   		
+   		System.out.println(c.toMol());
+        InChiResult result = c.toInchi();
+        String key = result.getKey();
+        System.out.println(key);
+        assertEquals("UHOVQNZJYSORNB-UHFFFAOYSA-N", key);
+
+
+   	}
+   	
+   	@Test
+   	public void testSimplestDearomatization() throws Exception {
+   		Chemical c=Chemical.parse("\n" + 
+   				"   JSDraw209262021582D\n" + 
+   				"\n" + 
+   				"  6  6  0  0  0  0              0 V2000\n" + 
+   				"   21.8408   -6.9164    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0\n" + 
+   				"   23.1920   -6.1369    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0\n" + 
+   				"   24.5432   -6.9164    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0\n" + 
+   				"   24.5432   -8.4756    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0\n" + 
+   				"   21.8408   -8.4756    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0\n" + 
+   				"   23.1920   -9.2551    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0\n" + 
+   				"  1  2  4  0  0  0  0\n" + 
+   				"  2  3  4  0  0  0  0\n" + 
+   				"  3  4  4  0  0  0  0\n" + 
+   				"  1  5  4  0  0  0  0\n" + 
+   				"  5  6  4  0  0  0  0\n" + 
+   				"  4  6  4  0  0  0  0\n" + 
+   				"M  END");
+   		c.kekulize();
+   		
+   		long l=c.bonds().filter(b->b.getBondType().equals(BondType.SINGLE) || b.getBondType().equals(BondType.DOUBLE))
+   		         .count();
+   		
+   		System.out.println(c.toMol());
+   		assertEquals(6,l);
+
 
    	}
 }

--- a/src/test/java/TestChiralRead.java
+++ b/src/test/java/TestChiralRead.java
@@ -365,4 +365,62 @@ public class TestChiralRead {
 			
 			assertEquals("Parity_Either", sdfChiral);
 	   	}
+		@Test
+	   	public void testRemoveNonDescriptHydrogensDoesntRemoveStereoInformationOnMol() throws Exception {
+
+	   		Chemical mol=Chemical.parse("\n" + 
+	   				"   JSDraw209282016242D\n" + 
+	   				"\n" + 
+	   				"  8  7  0  0  1  0            999 V2000\n" + 
+	   				"   28.5600   -9.6110    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0\n" + 
+	   				"   28.0990   -8.1210    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0\n" + 
+	   				"   27.6380   -9.6110    0.0000 H   0  0  0  0  0  0  0  0  0  0  0  0\n" + 
+	   				"   29.4510   -7.3410    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0\n" + 
+	   				"   30.9720   -7.6870    0.0000 H   0  0  0  0  0  0  0  0  0  0  0  0\n" + 
+	   				"   30.5110   -8.4850    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0\n" + 
+	   				"   29.4510   -5.7810    0.0000 O   0  0  0  0  0  0  0  0  0  0  0  0\n" + 
+	   				"   26.7480   -7.3410    0.0000 N   0  0  0  0  0  0  0  0  0  0  0  0\n" + 
+	   				"  1  2  1  0  0  0  0\n" + 
+	   				"  2  3  1  1  0  0  0\n" + 
+	   				"  2  4  1  0  0  0  0\n" + 
+	   				"  4  5  1  6  0  0  0\n" + 
+	   				"  4  6  1  0  0  0  0\n" + 
+	   				"  4  7  1  0  0  0  0\n" + 
+	   				"  2  8  1  0  0  0  0\n" + 
+	   				"M  END");
+	   		mol= Chemical.parse(mol.toMol());
+	   		Chemical mol2= Chemical.parse(mol.toSmiles());
+	   		mol2.removeNonDescriptHydrogens();
+	   		mol2.generateCoordinates();
+	   		mol2=Chemical.parse(mol2.toMol());
+	   		
+	   		String sdfChiral = mol2.atoms()
+					 .map(ca->ca.getChirality())
+					 .filter(ch->!ch.equals(Chirality.Non_Chiral))
+					 .map(ch->ch.toString())
+					 .collect(Collectors.joining());
+			
+			assertEquals("SS", sdfChiral);
+	   		
+	   	}
+	  	
+	  	@Test
+	   	public void testMethaneRemoveNonDescriptHydrogensMakesRightSmiles() throws Exception {
+	   		Chemical mol=Chemical.parse("\n" + 
+	   				"   JSDraw209282013552D\n" + 
+	   				"\n" + 
+	   				"  4  3  0  0  0  0            999 V2000\n" + 
+	   				"   18.7200  -10.7328    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0\n" + 
+	   				"   20.0710   -9.9528    0.0000 H   0  0  0  0  0  0  0  0  0  0  0  0\n" + 
+	   				"   18.7200  -12.2928    0.0000 H   0  0  0  0  0  0  0  0  0  0  0  0\n" + 
+	   				"   17.3690   -9.9528    0.0000 H   0  0  0  0  0  0  0  0  0  0  0  0\n" + 
+	   				"  1  2  1  0  0  0  0\n" + 
+	   				"  1  3  1  0  0  0  0\n" + 
+	   				"  1  4  1  0  0  0  0\n" + 
+	   				"M  END");
+	   		mol=Chemical.parse(mol.toSmiles());
+	   		mol.removeNonDescriptHydrogens();
+	   		assertEquals("C", mol.toSmiles());
+	   	}
+	  	
 }

--- a/src/test/java/TestChiralRead.java
+++ b/src/test/java/TestChiralRead.java
@@ -20,7 +20,9 @@
  */
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.*;
 
+import java.util.Optional;
 import java.util.stream.Collectors;
 
 import org.junit.Test;
@@ -180,6 +182,8 @@ public class TestChiralRead {
 					"M  END";
 			Chemical c=Chemical.parse(mm);
 			
+			System.out.println(mm);
+			
 			String genChiral = c.atoms()
 			 .map(ca->ca.getChirality())
 			 .filter(ch->!ch.equals(Chirality.Non_Chiral))
@@ -211,4 +215,154 @@ public class TestChiralRead {
 			assertEquals(genChiral,sdfChiral);
 			
 		}
+		
+		@Test
+	   	public void testSimpleTetrahedralStereoMarked() throws Exception {
+			Chemical c1=Chemical.parse("\n" + 
+					"   JSDraw209282010112D\n" + 
+					"\n" + 
+					"  5  4  0  0  0  0              0 V2000\n" + 
+					"   23.6688   -9.1798    0.0000 N   0  0  0  0  0  0  0  0  0  0  0  0\n" + 
+					"   25.1766   -9.2022    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0\n" + 
+					"   26.5285   -9.1725    0.0000 S   0  0  0  0  0  0  0  0  0  0  0  0\n" + 
+					"   25.1766   -7.6422    0.0000 O   0  0  0  0  0  0  0  0  0  0  0  0\n" + 
+					"   25.1766  -10.7622    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0\n" + 
+					"  1  2  1  0  0  0  0\n" + 
+					"  2  3  1  0  0  0  0\n" + 
+					"  2  4  1  0  0  0  0\n" + 
+					"  2  5  1  0  0  0  0\n" + 
+					"M  END\n" + 
+					"");
+			
+//			System.out.println(c1.toMol());
+			
+			Optional<Chirality> opChi=c1.atoms()
+			  .filter(ca->ca.getChirality()!=Chirality.Non_Chiral)
+			  .map(ca->ca.getChirality())
+			  .findFirst();
+			assertTrue(opChi.isPresent());
+			assertEquals(Chirality.Parity_Either, opChi.get());
+	   	}
+		/*
+
+		 */
+		
+		@Test
+	   	public void testSimpleTetrahedralStereoMarked2() throws Exception {
+			Chemical c1=Chemical.parse("\n" + 
+					"   JSDraw209282010292D\n" + 
+					"\n" + 
+					" 26 26  0  0  1  0            999 V2000\n" + 
+					"   41.5969   -8.3170    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0\n" + 
+					"   40.0369   -8.3170    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0\n" + 
+					"   39.2569   -9.6679    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0\n" + 
+					"   40.0369  -11.0188    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0\n" + 
+					"   37.6969   -9.6679    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0\n" + 
+					"   36.9169  -11.0199    0.0000 N   0  0  0  0  0  0  0  0  0  0  0  0\n" + 
+					"   37.6969  -12.3614    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0\n" + 
+					"   39.2569  -12.3588    0.0000 O   0  0  0  0  0  0  0  0  0  0  0  0\n" + 
+					"   36.9169  -13.7134    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0\n" + 
+					"   37.6971  -15.0642    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0\n" + 
+					"   39.2571  -15.0640    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0\n" + 
+					"   40.0302  -13.7090    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0\n" + 
+					"   41.5640  -13.6862    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0\n" + 
+					"   42.3968  -15.0595    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0\n" + 
+					"   43.9567  -15.0387    0.0000 O   0  0  0  0  0  0  0  0  0  0  0  0\n" + 
+					"   41.6237  -16.4143    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0\n" + 
+					"   40.0177  -16.3960    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0\n" + 
+					"   35.3570  -13.7134    0.0000 N   0  0  0  0  0  0  0  0  0  0  0  0\n" + 
+					"   34.5770  -15.0654    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0\n" + 
+					"   35.3572  -16.4162    0.0000 O   0  0  0  0  0  0  0  0  0  0  0  0\n" + 
+					"   33.0170  -15.0654    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0\n" + 
+					"   32.2368  -16.4162    0.0000 N   0  0  0  0  0  0  0  0  0  0  0  0\n" + 
+					"   32.2370  -13.7134    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0\n" + 
+					"   30.6771  -13.7134    0.0000 S   0  0  0  0  0  0  0  0  0  0  0  0\n" + 
+					"   36.9169   -8.3159    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0\n" + 
+					"   37.6971   -6.9651    0.0000 O   0  0  0  0  0  0  0  0  0  0  0  0\n" + 
+					"  1  2  1  0  0  0  0\n" + 
+					"  2  3  1  0  0  0  0\n" + 
+					"  3  4  1  6  0  0  0\n" + 
+					"  3  5  1  0  0  0  0\n" + 
+					"  5  6  1  6  0  0  0\n" + 
+					"  6  7  1  0  0  0  0\n" + 
+					"  7  8  2  0  0  0  0\n" + 
+					"  7  9  1  0  0  0  0\n" + 
+					"  9 10  1  6  0  0  0\n" + 
+					" 10 11  1  0  0  0  0\n" + 
+					" 11 12  2  0  0  0  0\n" + 
+					" 12 13  1  0  0  0  0\n" + 
+					" 13 14  2  0  0  0  0\n" + 
+					" 14 15  1  0  0  0  0\n" + 
+					" 14 16  1  0  0  0  0\n" + 
+					" 16 17  2  0  0  0  0\n" + 
+					" 11 17  1  0  0  0  0\n" + 
+					"  9 18  1  0  0  0  0\n" + 
+					" 18 19  1  0  0  0  0\n" + 
+					" 19 20  2  0  0  0  0\n" + 
+					" 19 21  1  0  0  0  0\n" + 
+					" 21 22  1  1  0  0  0\n" + 
+					" 21 23  1  0  0  0  0\n" + 
+					" 23 24  1  0  0  0  0\n" + 
+					"  5 25  1  0  0  0  0\n" + 
+					" 25 26  2  0  0  0  0\n" + 
+					"M  END");
+			String sdfChiral = c1.atoms()
+					 .map(ca->ca.getChirality())
+					 .filter(ch->!ch.equals(Chirality.Non_Chiral))
+					 .map(ch->ch.toString())
+					 .collect(Collectors.joining());
+			
+			assertEquals("SSSR", sdfChiral);
+	   	}
+
+		@Test
+	   	public void testSulfoxideStereo() throws Exception {
+			Chemical c1=Chemical.parse("\n" + 
+					"   JSDraw209282010442D\n" + 
+					"\n" + 
+					"  5  4  0  0  1  0            999 V2000\n" + 
+					"   16.7440   -8.8731    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0\n" + 
+					"   18.0950   -8.0931    0.0000 S   0  3  0  0  0  0  0  0  0  0  0  0\n" + 
+					"   19.4460   -8.8731    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0\n" + 
+					"   20.7970   -8.0931    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0\n" + 
+					"   18.0950   -6.5331    0.0000 O   0  5  0  0  0  0  0  0  0  0  0  0\n" + 
+					"  1  2  1  0  0  0  0\n" + 
+					"  2  3  1  0  0  0  0\n" + 
+					"  3  4  1  0  0  0  0\n" + 
+					"  2  5  1  1  0  0  0\n" + 
+					"M  CHG  2   2   1   5  -1\n" + 
+					"M  END");
+			String sdfChiral = c1.atoms()
+					 .map(ca->ca.getChirality())
+					 .filter(ch->!ch.equals(Chirality.Non_Chiral))
+					 .map(ch->ch.toString())
+					 .collect(Collectors.joining());
+			
+			assertEquals("R", sdfChiral);
+	   	}
+		@Test
+	   	public void testSulfoxideStereoPossible() throws Exception {
+			Chemical c1=Chemical.parse("\n" + 
+					"   JSDraw209282010462D\n" + 
+					"\n" + 
+					"  5  4  0  0  0  0            999 V2000\n" + 
+					"   16.7440   -8.8731    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0\n" + 
+					"   18.0950   -8.0931    0.0000 S   0  3  0  0  0  0  0  0  0  0  0  0\n" + 
+					"   19.4460   -8.8731    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0\n" + 
+					"   20.7970   -8.0931    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0\n" + 
+					"   18.0950   -6.5331    0.0000 O   0  5  0  0  0  0  0  0  0  0  0  0\n" + 
+					"  1  2  1  0  0  0  0\n" + 
+					"  2  3  1  0  0  0  0\n" + 
+					"  3  4  1  0  0  0  0\n" + 
+					"  2  5  1  0  0  0  0\n" + 
+					"M  CHG  2   2   1   5  -1\n" + 
+					"M  END");
+			String sdfChiral = c1.atoms()
+					 .map(ca->ca.getChirality())
+					 .filter(ch->!ch.equals(Chirality.Non_Chiral))
+					 .map(ch->ch.toString())
+					 .collect(Collectors.joining());
+			
+			assertEquals("Parity_Either", sdfChiral);
+	   	}
 }

--- a/src/test/java/TestChiralRead.java
+++ b/src/test/java/TestChiralRead.java
@@ -234,8 +234,6 @@ public class TestChiralRead {
 					"M  END\n" + 
 					"");
 			
-//			System.out.println(c1.toMol());
-			
 			Optional<Chirality> opChi=c1.atoms()
 			  .filter(ca->ca.getChirality()!=Chirality.Non_Chiral)
 			  .map(ca->ca.getChirality())
@@ -243,6 +241,37 @@ public class TestChiralRead {
 			assertTrue(opChi.isPresent());
 			assertEquals(Chirality.Parity_Either, opChi.get());
 	   	}
+		@Test
+	   	public void testSimpleTetrahedralStereoMarkedAsCenter() throws Exception {
+			Chemical c1=Chemical.parse("\n" + 
+					"   JSDraw209282010112D\n" + 
+					"\n" + 
+					"  5  4  0  0  0  0              0 V2000\n" + 
+					"   23.6688   -9.1798    0.0000 N   0  0  0  0  0  0  0  0  0  0  0  0\n" + 
+					"   25.1766   -9.2022    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0\n" + 
+					"   26.5285   -9.1725    0.0000 S   0  0  0  0  0  0  0  0  0  0  0  0\n" + 
+					"   25.1766   -7.6422    0.0000 O   0  0  0  0  0  0  0  0  0  0  0  0\n" + 
+					"   25.1766  -10.7622    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0\n" + 
+					"  1  2  1  0  0  0  0\n" + 
+					"  2  3  1  0  0  0  0\n" + 
+					"  2  4  1  0  0  0  0\n" + 
+					"  2  5  1  0  0  0  0\n" + 
+					"M  END\n" + 
+					"");
+//			c1.getAllStereocenters()
+//				.forEach(s->{
+//					System.out.println(s.getChirality());
+//				});
+			
+			Optional<Chirality> opChi=c1.getAllStereocenters().stream()
+			  .map(ca->ca.getChirality())
+			  .findFirst();
+			assertTrue(opChi.isPresent());
+			assertEquals(Chirality.Parity_Either, opChi.get());
+	   	}
+		
+		
+		
 		/*
 
 		 */
@@ -389,7 +418,12 @@ public class TestChiralRead {
 	   				"  2  8  1  0  0  0  0\n" + 
 	   				"M  END");
 	   		mol= Chemical.parse(mol.toMol());
-	   		Chemical mol2= Chemical.parse(mol.toSmiles());
+	   		Chemical mol2= Chemical.createFromSmiles(mol.toSmiles());
+	   		if(!mol2.hasCoordinates()){
+	   			mol2.generateCoordinates();
+	   		}
+	   		System.out.println(mol2.hasCoordinates());
+	   		System.out.println(mol2.toMol());
 	   		mol2.removeNonDescriptHydrogens();
 	   		mol2.generateCoordinates();
 	   		mol2=Chemical.parse(mol2.toMol());
@@ -401,8 +435,36 @@ public class TestChiralRead {
 					 .collect(Collectors.joining());
 			
 			assertEquals("SS", sdfChiral);
-	   		
 	   	}
+		@Test
+	   	public void testReadingSmilesShouldNotGenerateCoordinates() throws Exception {
+
+	   		Chemical mol=Chemical.parse("\n" + 
+	   				"   JSDraw209282016242D\n" + 
+	   				"\n" + 
+	   				"  8  7  0  0  1  0            999 V2000\n" + 
+	   				"   28.5600   -9.6110    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0\n" + 
+	   				"   28.0990   -8.1210    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0\n" + 
+	   				"   27.6380   -9.6110    0.0000 H   0  0  0  0  0  0  0  0  0  0  0  0\n" + 
+	   				"   29.4510   -7.3410    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0\n" + 
+	   				"   30.9720   -7.6870    0.0000 H   0  0  0  0  0  0  0  0  0  0  0  0\n" + 
+	   				"   30.5110   -8.4850    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0\n" + 
+	   				"   29.4510   -5.7810    0.0000 O   0  0  0  0  0  0  0  0  0  0  0  0\n" + 
+	   				"   26.7480   -7.3410    0.0000 N   0  0  0  0  0  0  0  0  0  0  0  0\n" + 
+	   				"  1  2  1  0  0  0  0\n" + 
+	   				"  2  3  1  1  0  0  0\n" + 
+	   				"  2  4  1  0  0  0  0\n" + 
+	   				"  4  5  1  6  0  0  0\n" + 
+	   				"  4  6  1  0  0  0  0\n" + 
+	   				"  4  7  1  0  0  0  0\n" + 
+	   				"  2  8  1  0  0  0  0\n" + 
+	   				"M  END");
+	   		Chemical mol2= Chemical.createFromSmiles(mol.toSmiles());
+	   		
+			
+			assertEquals("false", mol2.hasCoordinates()+"");
+	   	}
+		
 	  	
 	  	@Test
 	   	public void testMethaneRemoveNonDescriptHydrogensMakesRightSmiles() throws Exception {
@@ -421,6 +483,39 @@ public class TestChiralRead {
 	   		mol=Chemical.parse(mol.toSmiles());
 	   		mol.removeNonDescriptHydrogens();
 	   		assertEquals("C", mol.toSmiles());
+	   	}
+	  	
+	  	@Test
+	   	public void testSimpleExtendedTetrahedralStereoMarkedAsCenter() throws Exception {
+			Chemical c1=Chemical.parse("\n" + 
+					"   JSDraw209282018142D\n" + 
+					"\n" + 
+					"  7  6  0  0  1  0            999 V2000\n" + 
+					"   10.0360   -7.4984    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0\n" + 
+					"   11.3870   -6.7184    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0\n" + 
+					"   13.0510   -5.7824    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0\n" + 
+					"   10.0360   -9.0584    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0\n" + 
+					"    8.6850   -6.7184    0.0000 O   0  0  0  0  0  0  0  0  0  0  0  0\n" + 
+					"   13.0510   -4.2224    0.0000 N   0  0  0  0  0  0  0  0  0  0  0  0\n" + 
+					"   14.4540   -6.5624    0.0000 S   0  0  0  0  0  0  0  0  0  0  0  0\n" + 
+					"  1  2  2  0  0  0  0\n" + 
+					"  2  3  2  0  0  0  0\n" + 
+					"  1  4  1  0  0  0  0\n" + 
+					"  1  5  1  0  0  0  0\n" + 
+					"  3  6  1  6  0  0  0\n" + 
+					"  3  7  1  1  0  0  0\n" + 
+					"M  END");
+//			c1.getAllStereocenters()
+//				.forEach(s->{
+//					System.out.println(s);
+//					System.out.println(s.getChirality());
+//				});
+//			
+			Optional<Chirality> opChi=c1.getAllStereocenters().stream()
+			  .map(ca->ca.getChirality())
+			  .findFirst();
+			assertTrue(opChi.isPresent());
+			assertEquals(Chirality.S, opChi.get());
 	   	}
 	  	
 }

--- a/src/test/java/TestChiralRead.java
+++ b/src/test/java/TestChiralRead.java
@@ -1,0 +1,214 @@
+/*
+ * NCATS-MOLWITCH-CDK
+ *
+ * Copyright (c) 2020.
+ *
+ * This work is free software; you can redistribute it and/or modify it under the terms of the
+ * GNU Lesser General Public License as published by the Free Software Foundation;
+ * either version 2.1 of the License, or (at your option) any later version.
+ *
+ * This work is distributed in the hope that it will be useful, but without any warranty;
+ * without even the implied warranty of merchantability or fitness for a particular purpose.
+ * See the GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along with this library;
+ *  if not, write to:
+ *
+ *  the Free Software Foundation, Inc.
+ *  59 Temple Place, Suite 330
+ *  Boston, MA 02111-1307 USA
+ */
+
+import static org.junit.Assert.assertEquals;
+
+import java.util.stream.Collectors;
+
+import org.junit.Test;
+
+import gov.nih.ncats.molwitch.Chemical;
+import gov.nih.ncats.molwitch.Chirality;
+import gov.nih.ncats.molwitch.io.ChemicalReaderFactory;
+
+public class TestChiralRead {
+		@Test
+	   public void ensureChiralityIsTheSameRegardlessOfSDFOrMolOrAgnosticRead() throws Exception{
+ 	   
+ 	   String mm="\n" + 
+					"  CDK     09262014553D\n" + 
+					"\n" + 
+					" 69 71  0  0  1  0  0  0  0  0999 V2000\n" + 
+					"    7.4100    3.6690    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0\n" + 
+					"    5.9100    3.6690    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0\n" + 
+					"    5.1600    2.3700    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0\n" + 
+					"    5.9100    1.0710    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0\n" + 
+					"    3.6600    2.3700    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0\n" + 
+					"    2.9100    1.0700    0.0000 N   0  0  0  0  0  0  0  0  0  0  0  0\n" + 
+					"    3.6600   -0.2200    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0\n" + 
+					"    5.1600   -0.2175    0.0000 O   0  0  0  0  0  0  0  0  0  0  0  0\n" + 
+					"    2.9100   -1.5200    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0\n" + 
+					"    3.6602   -2.8189    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0\n" + 
+					"    5.1602   -2.8187    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0\n" + 
+					"    5.9036   -1.5158    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0\n" + 
+					"    7.3784   -1.4938    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0\n" + 
+					"    8.1792   -2.8143    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0\n" + 
+					"    9.6791   -2.7943    0.0000 O   0  0  0  0  0  0  0  0  0  0  0  0\n" + 
+					"    7.4358   -4.1171    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0\n" + 
+					"    5.8916   -4.0995    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0\n" + 
+					"    1.4100   -1.5200    0.0000 N   0  0  0  0  0  0  0  0  0  0  0  0\n" + 
+					"    0.6600   -2.8200    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0\n" + 
+					"    1.4102   -4.1189    0.0000 O   0  0  0  0  0  0  0  0  0  0  0  0\n" + 
+					"   -0.8400   -2.8200    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0\n" + 
+					"   -1.5902   -4.1189    0.0000 N   0  0  0  0  0  0  0  0  0  0  0  0\n" + 
+					"   -1.5900   -1.5200    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0\n" + 
+					"   -3.0900   -1.5200    0.0000 S   0  0  0  0  0  0  0  0  0  0  0  0\n" + 
+					"   -3.8400   -0.2200    0.0000 S   0  0  0  0  0  0  0  0  0  0  0  0\n" + 
+					"   -5.3400   -0.2200    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0\n" + 
+					"   -6.0900    1.0700    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0\n" + 
+					"   -5.3400    2.3700    0.0000 N   0  0  0  0  0  0  0  0  0  0  0  0\n" + 
+					"   -3.8400    2.3700    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0\n" + 
+					"   -3.0898    1.0711    0.0000 O   0  0  0  0  0  0  0  0  0  0  0  0\n" + 
+					"   -3.0900    3.6700    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0\n" + 
+					"   -3.8402    4.9689    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0\n" + 
+					"   -5.3402    4.9687    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0\n" + 
+					"   -6.0904    6.2676    0.0000 N   0  0  0  0  0  0  0  0  0  0  0  0\n" + 
+					"   -6.0900    3.6695    0.0000 O   0  0  0  0  0  0  0  0  0  0  0  0\n" + 
+					"   -1.5900    3.6700    0.0000 N   0  0  0  0  0  0  0  0  0  0  0  0\n" + 
+					"   -0.8400    4.9700    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0\n" + 
+					"   -1.5902    6.2689    0.0000 O   0  0  0  0  0  0  0  0  0  0  0  0\n" + 
+					"    0.6600    4.9700    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0\n" + 
+					"    1.4102    6.2689    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0\n" + 
+					"    0.6604    7.5681    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0\n" + 
+					"    1.4106    8.8670    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0\n" + 
+					"    0.6608   10.1662    0.0000 N   0  0  0  0  0  0  0  0  0  0  0  0\n" + 
+					"    2.9106    8.8668    0.0000 O   0  0  0  0  0  0  0  0  0  0  0  0\n" + 
+					"    1.4100    3.6700    0.0000 N   0  0  0  0  0  0  0  0  0  0  0  0\n" + 
+					"    2.9100    3.6700    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0\n" + 
+					"    3.6602    4.9689    0.0000 O   0  0  0  0  0  0  0  0  0  0  0  0\n" + 
+					"   -7.5900    1.0675    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0\n" + 
+					"   -8.3422    2.3653    0.0000 O   0  0  0  0  0  0  0  0  0  0  0  0\n" + 
+					"   -8.3378   -0.2328    0.0000 N   0  0  0  0  0  0  0  0  0  0  0  0\n" + 
+					"   -7.7250   -1.5977    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0\n" + 
+					"   -8.8347   -2.6101    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0\n" + 
+					"  -10.1364   -1.8649    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0\n" + 
+					"   -9.8338   -0.3903    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0\n" + 
+					"  -10.8415    0.7208    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0\n" + 
+					"  -10.3831    2.1490    0.0000 O   0  0  0  0  0  0  0  0  0  0  0  0\n" + 
+					"  -12.3076    0.4036    0.0000 N   0  0  0  0  0  0  0  0  0  0  0  0\n" + 
+					"  -13.3153    1.5147    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0\n" + 
+					"  -12.8569    2.9429    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0\n" + 
+					"  -13.8647    4.0540    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0\n" + 
+					"  -15.3307    3.7369    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0\n" + 
+					"  -13.4063    5.4823    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0\n" + 
+					"  -14.7814    1.1975    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0\n" + 
+					"  -15.2398   -0.2307    0.0000 O   0  0  0  0  0  0  0  0  0  0  0  0\n" + 
+					"  -15.7891    2.3086    0.0000 N   0  0  0  0  0  0  0  0  0  0  0  0\n" + 
+					"  -17.2552    1.9915    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0\n" + 
+					"  -18.2629    3.1025    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0\n" + 
+					"  -19.7290    2.7854    0.0000 N   0  0  0  0  0  0  0  0  0  0  0  0\n" + 
+					"  -17.8045    4.5308    0.0000 O   0  0  0  0  0  0  0  0  0  0  0  0\n" + 
+					"  1  2  1  0  0  0  0\n" + 
+					"  2  3  1  0  0  0  0\n" + 
+					"  3  4  1  6  0  0  0\n" + 
+					"  3  5  1  0  0  0  0\n" + 
+					"  5  6  1  6  0  0  0\n" + 
+					"  6  7  1  0  0  0  0\n" + 
+					"  7  8  2  0  0  0  0\n" + 
+					"  7  9  1  0  0  0  0\n" + 
+					"  9 10  1  6  0  0  0\n" + 
+					" 10 11  1  0  0  0  0\n" + 
+					" 11 12  2  0  0  0  0\n" + 
+					" 12 13  1  0  0  0  0\n" + 
+					" 13 14  2  0  0  0  0\n" + 
+					" 14 15  1  0  0  0  0\n" + 
+					" 14 16  1  0  0  0  0\n" + 
+					" 16 17  2  0  0  0  0\n" + 
+					" 11 17  1  0  0  0  0\n" + 
+					"  9 18  1  0  0  0  0\n" + 
+					" 18 19  1  0  0  0  0\n" + 
+					" 19 20  2  0  0  0  0\n" + 
+					" 19 21  1  0  0  0  0\n" + 
+					" 21 22  1  1  0  0  0\n" + 
+					" 21 23  1  0  0  0  0\n" + 
+					" 23 24  1  0  0  0  0\n" + 
+					" 24 25  1  0  0  0  0\n" + 
+					" 25 26  1  0  0  0  0\n" + 
+					" 26 27  1  0  0  0  0\n" + 
+					" 27 28  1  0  0  0  0\n" + 
+					" 28 29  1  0  0  0  0\n" + 
+					" 29 30  2  0  0  0  0\n" + 
+					" 29 31  1  0  0  0  0\n" + 
+					" 31 32  1  6  0  0  0\n" + 
+					" 32 33  1  0  0  0  0\n" + 
+					" 33 34  1  0  0  0  0\n" + 
+					" 33 35  2  0  0  0  0\n" + 
+					" 31 36  1  0  0  0  0\n" + 
+					" 36 37  1  0  0  0  0\n" + 
+					" 37 38  2  0  0  0  0\n" + 
+					" 37 39  1  0  0  0  0\n" + 
+					" 39 40  1  6  0  0  0\n" + 
+					" 40 41  1  0  0  0  0\n" + 
+					" 41 42  1  0  0  0  0\n" + 
+					" 42 43  1  0  0  0  0\n" + 
+					" 42 44  2  0  0  0  0\n" + 
+					" 39 45  1  0  0  0  0\n" + 
+					" 45 46  1  0  0  0  0\n" + 
+					"  5 46  1  0  0  0  0\n" + 
+					" 46 47  2  0  0  0  0\n" + 
+					" 27 48  1  1  0  0  0\n" + 
+					" 48 49  2  0  0  0  0\n" + 
+					" 48 50  1  0  0  0  0\n" + 
+					" 50 51  1  0  0  0  0\n" + 
+					" 51 52  1  0  0  0  0\n" + 
+					" 52 53  1  0  0  0  0\n" + 
+					" 53 54  1  0  0  0  0\n" + 
+					" 50 54  1  0  0  0  0\n" + 
+					" 54 55  1  1  0  0  0\n" + 
+					" 55 56  2  0  0  0  0\n" + 
+					" 55 57  1  0  0  0  0\n" + 
+					" 58 57  1  6  0  0  0\n" + 
+					" 58 59  1  0  0  0  0\n" + 
+					" 59 60  1  0  0  0  0\n" + 
+					" 60 61  1  0  0  0  0\n" + 
+					" 60 62  1  0  0  0  0\n" + 
+					" 58 63  1  0  0  0  0\n" + 
+					" 63 64  2  0  0  0  0\n" + 
+					" 63 65  1  0  0  0  0\n" + 
+					" 65 66  1  0  0  0  0\n" + 
+					" 66 67  1  0  0  0  0\n" + 
+					" 67 68  1  0  0  0  0\n" + 
+					" 67 69  2  0  0  0  0\n" + 
+					"M  END";
+			Chemical c=Chemical.parse(mm);
+			
+			String genChiral = c.atoms()
+			 .map(ca->ca.getChirality())
+			 .filter(ch->!ch.equals(Chirality.Non_Chiral))
+			 .map(ch->ch.toString())
+			 .collect(Collectors.joining());
+			
+			System.out.println("CHIRALITY FROM GENERIC PARSE:" + genChiral);
+			
+			c=Chemical.parseMol(mm);
+			String molChiral = c.atoms()
+					 .map(ca->ca.getChirality())
+					 .filter(ch->!ch.equals(Chirality.Non_Chiral))
+					 .map(ch->ch.toString())
+					 .collect(Collectors.joining());
+
+			System.out.println("CHIRALITY FROM MOL PARSE:" + molChiral);
+			
+			c=new Chemical(ChemicalReaderFactory.read("sdf", mm + "\n$$$$"));
+			
+			String sdfChiral = c.atoms()
+					 .map(ca->ca.getChirality())
+					 .filter(ch->!ch.equals(Chirality.Non_Chiral))
+					 .map(ch->ch.toString())
+					 .collect(Collectors.joining());
+			
+			System.out.println("CHIRALITY FROM SDF PARSE:" + sdfChiral);
+			
+			assertEquals(genChiral,molChiral);
+			assertEquals(genChiral,sdfChiral);
+			
+		}
+}

--- a/src/test/java/TestParseQueryMol.java
+++ b/src/test/java/TestParseQueryMol.java
@@ -700,4 +700,14 @@ public class TestParseQueryMol {
 			}
 			assertEquals("CCCCC", c.toSmiles());
 		}
+
+	   	@Test
+	   	public void testQueryAtomMolfileHasWriteAtoms() throws Exception {
+	   		Chemical c=Chemical.parse("S(=O)(=O)(O)OC[#6]");
+	   		Chemical c2= Chemical.parse(c.toMol());
+	   		boolean hasSulfur = c2.atoms().filter(ca->"S".equals(ca.getSymbol())).count()>0;
+	       	assertTrue("Simple SMARTS keeps its atom types", hasSulfur);
+	   		
+	
+	   	}
 }

--- a/src/test/java/TestParseQueryMol.java
+++ b/src/test/java/TestParseQueryMol.java
@@ -714,6 +714,19 @@ public class TestParseQueryMol {
 
 	
 	   	}
+	   	
+	  	@Test
+	   	public void testQueryAtomMolfileHasWriteAtoms2() throws Exception {
+	   		Chemical c=Chemical.parse("S(=O)(=O)(O)OC[#6,#7]");
+	   		System.out.println(c.toMol());
+	   		Chemical c2= Chemical.parse(c.toMol());
+	   		boolean hasSulfur = c2.atoms().filter(ca->"S".equals(ca.getSymbol())).count()>0;
+	       	assertTrue("Simple SMARTS keeps its atom types", hasSulfur);
+	       	assertTrue("Simple SMARTS keeps atom list", c.toMol().contains("0.0000 L   0"));
+	   		
+
+	
+	   	}
 	  
 	   	
 }

--- a/src/test/java/TestParseQueryMol.java
+++ b/src/test/java/TestParseQueryMol.java
@@ -32,11 +32,13 @@ import org.junit.Test;
 
 import gov.nih.ncats.molwitch.Atom;
 import gov.nih.ncats.molwitch.Bond;
+import gov.nih.ncats.molwitch.Bond.BondType;
 import gov.nih.ncats.molwitch.Chemical;
 import gov.nih.ncats.molwitch.fingerprint.Fingerprint;
 import gov.nih.ncats.molwitch.fingerprint.Fingerprinter;
 import gov.nih.ncats.molwitch.fingerprint.Fingerprinters;
 import gov.nih.ncats.molwitch.fingerprint.Fingerprinters.FingerprintSpecification;
+import gov.nih.ncats.molwitch.inchi.InChiResult;
 import gov.nih.ncats.molwitch.search.MolSearcherFactory;
 
 public class TestParseQueryMol {
@@ -709,7 +711,9 @@ public class TestParseQueryMol {
 	   		boolean hasSulfur = c2.atoms().filter(ca->"S".equals(ca.getSymbol())).count()>0;
 	       	assertTrue("Simple SMARTS keeps its atom types", hasSulfur);
 	   		
+
 	
 	   	}
+	  
 	   	
 }

--- a/src/test/java/TestParseQueryMol.java
+++ b/src/test/java/TestParseQueryMol.java
@@ -704,10 +704,12 @@ public class TestParseQueryMol {
 	   	@Test
 	   	public void testQueryAtomMolfileHasWriteAtoms() throws Exception {
 	   		Chemical c=Chemical.parse("S(=O)(=O)(O)OC[#6]");
+	   		System.out.println(c.toMol());
 	   		Chemical c2= Chemical.parse(c.toMol());
 	   		boolean hasSulfur = c2.atoms().filter(ca->"S".equals(ca.getSymbol())).count()>0;
 	       	assertTrue("Simple SMARTS keeps its atom types", hasSulfur);
 	   		
 	
 	   	}
+	   	
 }


### PR DESCRIPTION
This fixes several little issues and two big ones:

Big Ones
=====
1. Kekulization / aromatization pre-work is altered so that aromatic bonds are allowed for kekulization but not for aromatization (this is very critical, otherwise kekulization doesn't really work)
2. Stereochemistry/chirality detection now will return Parity_Either if the center exists but is not defined.

Little Ones
=======
1. Atom valence error check now does something for molfiles (not just smiles -- still should be improved)
2. parse and parseMol now use the same pipeline (though sdf parsing does not). This stops a stereo inversion problem.
3. added more tests for a few specific cases to ensure consistency
4. reading a smiles doesn't auto generate coordinates (faster if not needed, and avoids an issue where molfiles can be written and look okay but actually needed to have generation happen for them to include stereo bonds)

NEEDS TO BE DONE
=================
1. Fix for stopping SDF read inverting stereo. There's a test that still fails here.
2. Non-descript hydrogen removal needs to be updated in main chemical repo (pull request already there)